### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/PCF8574/keywords.txt
+++ b/PCF8574/keywords.txt
@@ -13,26 +13,26 @@ PCF8575	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin KEYWORD2
-pinMode KEYWORD2
-digitalWrite KEYWORD2
-digitalRead KEYWORD2
-write KEYWORD2
-read KEYWORD2
-clear KEYWORD2
-set KEYWORD2
-toggle KEYWORD2
-blink KEYWORD2
-attachInterrupt KEYWORD2
-detachInterrupt KEYWORD2
-disableInterrupt KEYWORD2
-enableInterrupt KEYWORD2
-checkForInterrupt KEYWORD2
-pullUp KEYWORD2
-pullDown KEYWORD2
+begin	KEYWORD2
+pinMode	KEYWORD2
+digitalWrite	KEYWORD2
+digitalRead	KEYWORD2
+write	KEYWORD2
+read	KEYWORD2
+clear	KEYWORD2
+set	KEYWORD2
+toggle	KEYWORD2
+blink	KEYWORD2
+attachInterrupt	KEYWORD2
+detachInterrupt	KEYWORD2
+disableInterrupt	KEYWORD2
+enableInterrupt	KEYWORD2
+checkForInterrupt	KEYWORD2
+pullUp	KEYWORD2
+pullDown	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-INPUT_PULLUP LITERAL1
+INPUT_PULLUP	LITERAL1

--- a/PCF8575/keywords.txt
+++ b/PCF8575/keywords.txt
@@ -13,26 +13,26 @@ PCF8575	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin KEYWORD2
-pinMode KEYWORD2
-digitalWrite KEYWORD2
-digitalRead KEYWORD2
-write KEYWORD2
-read KEYWORD2
-clear KEYWORD2
-set KEYWORD2
-toggle KEYWORD2
-blink KEYWORD2
-attachInterrupt KEYWORD2
-detachInterrupt KEYWORD2
-disableInterrupt KEYWORD2
-enableInterrupt KEYWORD2
-checkForInterrupt KEYWORD2
-pullUp KEYWORD2
-pullDown KEYWORD2
+begin	KEYWORD2
+pinMode	KEYWORD2
+digitalWrite	KEYWORD2
+digitalRead	KEYWORD2
+write	KEYWORD2
+read	KEYWORD2
+clear	KEYWORD2
+set	KEYWORD2
+toggle	KEYWORD2
+blink	KEYWORD2
+attachInterrupt	KEYWORD2
+detachInterrupt	KEYWORD2
+disableInterrupt	KEYWORD2
+enableInterrupt	KEYWORD2
+checkForInterrupt	KEYWORD2
+pullUp	KEYWORD2
+pullDown	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-INPUT_PULLUP LITERAL1
+INPUT_PULLUP	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords